### PR TITLE
User関連レイアウト実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -59,13 +59,12 @@ ul {
 
 .notice,
 .alert {
+  padding: 0;
   text-align: center;
-  font-size: 16px;
-  margin: 5px auto;
-  padding: 10px 15px;
-  display: inline-block;
-  border-radius: 10px;
+  font-size: 8px;
+  font-weight: bold;
   color: white;
+  margin: 0;
 }
 
 // ヘッダー
@@ -83,8 +82,40 @@ header {
       }
     }
     .header-right-nav {
-      .btn-appearance {
-        padding: 6px 20px;
+      float: right;
+      .nav-item {
+        display: inline-block;
+        color: #000;
+        font-size: 16px;
+        .icon-header {
+          width: 60px;
+          height: 60px;
+          object-fit: cover;
+          border-radius: 50%;
+        }
+        .header-nav-menu {
+          border: 2px solid #d4d7d8;
+          position: absolute;
+          top: 70px;
+          right: 10px;
+          background-color: #fff;
+          padding: 15px;
+          z-index: 1000;
+          li {
+            text-align: center;
+            line-height: 30px;
+            font-size: 16px;
+            padding: 3px 5px;
+            border-bottom: 1px solid #d4d7d8;
+            a {
+              color: #555657;
+              text-decoration: none;
+            }
+          }
+        }
+      }
+      .nav-name {
+        margin-right: 10px;
       }
     }
   }
@@ -121,6 +152,89 @@ header {
           }
         }
       }
+    }
+  }
+}
+
+// ユーザー登録フォーム
+.device {
+  padding-top: 36px;
+  font-size: 16px;
+  .device_frame {
+    max-width: 600px;
+    text-align: center;
+    padding: 24px;
+    margin: 0px auto;
+    background-color: #fff;
+    border-radius: 4px;
+    box-shadow: rgba(21, 27, 38, 0.15) 0px 1px 3px 0px;
+    p {
+      font-size: 18px;
+      font-weight: bold;
+    }
+    .device_inner {
+      width: 360px;
+      margin: 0px auto;
+      .field {
+        margin-bottom: 10px;
+        .required-b::before {
+          content: "必須";
+          color: #fff;
+          background-color: #ff0000a8;
+          font-size: 12px;
+          border-radius: 5px;
+          padding: 4px;
+          margin: 0 5px;
+        }
+        .form-control {
+          display: block;
+          width: 100%;
+          height: calc(1.5em + 0.75rem + 2px);
+          padding: 0.375rem 0.75rem;
+          font-size: 1rem;
+          font-weight: 400;
+          line-height: 1.5;
+          color: #495057;
+          background-color: #fff;
+          background-clip: padding-box;
+          border: 1px solid #ced4da;
+          border-radius: 0.25rem;
+          transition: border-color 0.15s ease-in-out,
+            box-shadow 0.15s ease-in-out;
+        }
+      }
+      .actions {
+        margin-bottom: 5px;
+      }
+    }
+  }
+}
+
+// ログイン
+.check_box {
+  margin-top: 15px;
+}
+// _link.html.erb
+.redirect_link {
+  font-size: 12px;
+}
+
+// エラーメッセージ
+#error_explanation {
+  background-color: #ec0000;
+  border-radius: 10px;
+  padding: 10px 20px;
+  color: #fff;
+  margin-bottom: 15px;
+  h2 {
+    font-size: 18px;
+    font-weight: bold;
+    text-align: center;
+  }
+  ul {
+    list-style: circle;
+    li {
+      text-align: left;
     }
   }
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :name, presence: true, length: { maximum: 50 }
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  validates :email, length: { maximum: 191 },
+                    format: { with: VALID_EMAIL_REGEX },
+                    uniqueness: true
+  validates :intro, length: { maximum: 191 }
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,12 +11,19 @@
     </div>
     <div class="header-right-nav">
       <% if user_signed_in? %>
-        <ul class="header-nav-menu">
-          <li><%= link_to "商品一覧", "" %></li>
-          <li><%= link_to "フォローしているユーザーの商品", "" %></li>
-          <li><%= link_to "設定", "" %></li>
-          <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
-        </ul>
+        <div class="nav-item nav-name d-sm-inline-block d-none">
+          <%= current_user.name %> 様
+        </div>
+        <div class="nav-item">
+          <input type="checkbox" id="toggle" />
+          <ul class="header-nav-menu">
+            <li><%= link_to "商品一覧", "" %></li>
+            <li><%= link_to "購入履歴", "" %></li>
+            <li><%= link_to "お気に入りカテゴリ", "" %></li>
+            <li><%= link_to "設定", "" %></li>
+            <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
+          </ul>
+        </div>
       <% else %>
         <%= link_to "会員登録（無料）", new_user_registration_path, class: "btn btn-first btn-appearance" %>
         <%=link_to "ログイン", new_user_session_path, class: "btn btn-second btn-appearance" %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,23 +1,30 @@
-<h2>Sign up</h2>
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="container device">
+  <div class="device_frame">
+    <p class="my-4">新規カウントを作成</p>
+    <div class="device_inner">
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render "users/shared/error_messages", resource: resource %>
+        <div class="field form-row">
+          <div class="col-2 required-b pt-2"></div>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name",placeholder: "ユーザー名", class: "form-control col-10 px-2" %>
+        </div>
+        <div class="field form-row">
+          <div class="col-2 required-b pt-2"></div>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", class: "form-control col-10 px-2" %>
+        </div>
+        <div class="field form-row">
+          <div class="col-2 required-b pt-2"></div>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード", class: "form-control col-10 px-2" %>
+        </div>
+        <div class="field form-row">
+          <div class="col-2 required-b pt-2"></div>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワード確認", class: "form-control col-10 px-2" %>
+        </div>
+        <div class="actions">
+          <%= f.submit "新しいアカウントを作成", class:"form-control my-4 btn-warning"%>
+        </div>
+      <% end %>
+      <%= render "users/shared/links" %>
+    </div>
   </div>
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,30 @@
-<h2>Log in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+<div class="container device">
+  <div class="device_frame">
+    <p class="my-4">ログイン</p>
+    <div class="device_inner">
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <%= render "users/shared/error_messages", resource: resource %>
+        <div class="field form-row">
+          <div class="col-2 required-b pt-2"></div>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", class: "form-control col-10 px-2" %>
+        </div>
+        <div class="field form-row">
+          <div class="col-2 required-b pt-2"></div>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワード", class: "form-control col-10 px-2" %>
+        </div>
+        <div class="check_box">
+          <% if devise_mapping.rememberable? %>
+            <div class="field">
+              <%= f.check_box :remember_me %>
+              <%= f.label :remember_me %>
+            </div>
+          <% end %>
+        </div>
+        <div class="actions">
+          <%= f.submit "ログイン", class:"form-control btn-warning my-4"%>
+        </div>
+      <% end %>
+      <%= render "users/shared/links" %>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,23 +1,18 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "すでにアカウントをお持ちの方はログイン", new_session_path(resource_name), class:"redirect_link"%><br />
 <% end %>
-
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "会員登録(無料)", new_registration_path(resource_name) , class:"redirect_link"%><br />
 <% end %>
-
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードを忘れた場合", new_password_path(resource_name), class:"redirect_link"%><br />
 <% end %>
-
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
 <% end %>
-
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
   <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
 <% end %>
-
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
     <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ Bundler.require(*Rails.groups)
 
 module LossPerori
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
     config.load_defaults 6.1
     config.generators.system_tests = nil
     config.i18n.default_locale = :ja

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -35,7 +35,7 @@ ja:
               confirmation: "が内容とあっていません。"
     attributes:
       user:
-        name: "名前"
+        name: "ユーザー名"
         avatar: "アイコン画像"
         email: "メールアドレス"
         password: "パスワード"
@@ -43,7 +43,7 @@ ja:
         password_confirmation: "パスワード確認"
       room:
     models:
-      user: "ユーザ"
+      user: "アカウント"
   devise:
     confirmations:
       new:

--- a/db/migrate/20210204003057_add_user_name_to_users.rb
+++ b/db/migrate/20210204003057_add_user_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddUserNameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :name, :string
+    add_column :users, :intro, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_02_063050) do
+ActiveRecord::Schema.define(version: 2021_02_04_003057) do
 
   create_table "users", charset: "utf8mb4", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 2021_02_02_063050) do
     t.string "unconfirmed_email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
+    t.text "intro"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
### Userモデルの実装に伴い、ログイン、新規登録ページのレイアウトを整えました。お手数をおかけいたしますが、ご確認をお願いいたします

#### 確認方法
- サーバーを立ち上げ、root_pathにアクセス
- header右側の会員登録、ログイン、ホームページ中央の会員登録から各ページにアクセス。
- 新規登録と、ロクインページに移動。

#### 確認してほしいポイント　
- 各ページのレイアウトが整っているか
- エラーが起きたときのフラッシュが日本語で正常に表示されるか
- エラーが起きたときのエラーメッセージが日本語で正常に表示されるか
- エラーメッセージのレイアウトが整っているか

Issues No. 各ユーザー認証ページのデザイン実装 #5